### PR TITLE
Add cosmos deps to types

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -14,7 +14,7 @@
   "files": [
     "/dist"
   ],
-  "peerDependencies": {
+  "dependencies": {
     "@cosmjs/cosmwasm-stargate": "^0.28.9",
     "@cosmjs/proto-signing": "^0.28.9",
     "@cosmjs/stargate": "^0.28.9"

--- a/packages/types/src/global.ts
+++ b/packages/types/src/global.ts
@@ -1,10 +1,9 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
-import {CosmWasmClient} from '@cosmjs/cosmwasm-stargate';
-import {Registry} from '@cosmjs/proto-signing';
-import {StargateClient} from '@cosmjs/stargate';
-import Pino from 'pino';
+import type {CosmWasmClient} from '@cosmjs/cosmwasm-stargate';
+import type {Registry} from '@cosmjs/proto-signing';
+import type Pino from 'pino';
 import {Store, DynamicDatasourceCreator} from './interfaces';
 
 declare global {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2772,11 +2772,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@subql/types-cosmos@workspace:packages/types"
   dependencies:
-    "@types/app-module-path": ^2.2.0
-  peerDependencies:
     "@cosmjs/cosmwasm-stargate": ^0.28.9
     "@cosmjs/proto-signing": ^0.28.9
     "@cosmjs/stargate": ^0.28.9
+    "@types/app-module-path": ^2.2.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Without these dependencies there is no type resolution for `api` and `registry`