### PR TITLE
Fix chainId instead of chain

### DIFF
--- a/packages/node/src/indexer/api.service.ts
+++ b/packages/node/src/indexer/api.service.ts
@@ -89,14 +89,13 @@ export class ApiService {
       this.api = new CosmosClient(tendermint, this.registry);
 
       this.networkMeta = {
-        chainId: network.chainId,
+        chain: network.chainId,
       };
 
       const chainId = await this.api.getChainId();
-      logger.info(chainId);
       if (network.chainId !== chainId) {
         const err = new Error(
-          `The given chainId does not match with client: "${network.chainId}"`,
+          `Network chainId doesn't match expected chainId. expected="${network.chainId}" actual="${chainId}`,
         );
         logger.error(err, err.message);
         throw err;

--- a/packages/node/src/indexer/events.ts
+++ b/packages/node/src/indexer/events.ts
@@ -32,7 +32,7 @@ export interface EventPayload<T> {
 }
 
 export interface NetworkMetadataPayload {
-  chainId: string;
+  chain: string;
 }
 
 export interface MmrPayload {

--- a/packages/node/src/indexer/project.service.ts
+++ b/packages/node/src/indexer/project.service.ts
@@ -3,12 +3,11 @@
 
 import assert from 'assert';
 import fs from 'fs';
-import { off } from 'process';
 import { isMainThread } from 'worker_threads';
 import { Inject, Injectable } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { getAllEntitiesRelations } from '@subql/utils';
-import { QueryTypes, Sequelize, Transaction } from 'sequelize';
+import { QueryTypes, Sequelize } from 'sequelize';
 import { NodeConfig } from '../configure/NodeConfig';
 import { SubqueryProject } from '../configure/SubqueryProject';
 import { SubqueryRepo } from '../entities';
@@ -202,10 +201,6 @@ export class ProjectService {
   private async ensureMetadata(): Promise<MetadataRepo> {
     const metadataRepo = MetadataFactory(this.sequelize, this.schema);
 
-    const project = await this.subqueryRepo.findOne({
-      where: { name: this.nodeConfig.subqueryName },
-    });
-
     this.eventEmitter.emit(
       IndexerEvent.NetworkMetadata,
       this.apiService.networkMeta,
@@ -230,7 +225,7 @@ export class ProjectService {
       return arr;
     }, {} as { [key in typeof keys[number]]: string | boolean | number });
 
-    const { chainId } = this.apiService.networkMeta;
+    const { chain } = this.apiService.networkMeta;
 
     if (this.project.runner) {
       await Promise.all([
@@ -252,8 +247,8 @@ export class ProjectService {
         }),
       ]);
     }
-    if (keyValue.chain !== chainId) {
-      await metadataRepo.upsert({ key: 'chain', value: chainId });
+    if (keyValue.chain !== chain) {
+      await metadataRepo.upsert({ key: 'chain', value: chain });
     }
 
     if (keyValue.indexerNodeVersion !== packageVersion) {


### PR DESCRIPTION
# Description
Change `chainId` to `chain` on meta http request.
Also improves message for unmatching chain Id

Fixes https://github.com/subquery/subql-cosmos/issues/47

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
