### PR TITLE
Convert endpoint apikey query param to header

### DIFF
--- a/packages/node/src/indexer/api.service.ts
+++ b/packages/node/src/indexer/api.service.ts
@@ -287,8 +287,17 @@ export class KeepAliveClient implements RpcClient {
       this.url = endpoint.url;
       this.headers = endpoint.headers;
     }
+
+    const { searchParams } = new URL(this.url);
+
+    // Support OnFinality api keys
+    if (searchParams.get('apikey')) {
+      this.headers.apikey = searchParams.get('apikey');
+    }
+
     const httpAgent = new http.Agent({ keepAlive: true, maxSockets: 10 });
     const httpsAgent = new https.Agent({ keepAlive: true, maxSockets: 10 });
+
     this.connection = axios.create({
       httpAgent,
       httpsAgent,


### PR DESCRIPTION
Fixes unable to use endpoints from OnFinality with api key in url 

e.g. `https://juno.api.onfinality.io/rpc?apikey=<your-api-key>`