### PR TITLE
Add the ability to filter by event attributes

### DIFF
--- a/packages/common-cosmos/src/project/models.ts
+++ b/packages/common-cosmos/src/project/models.ts
@@ -68,6 +68,9 @@ export class CosmosEventFilter implements SubqlCosmosEventFilter {
   @IsOptional()
   @Type(() => CosmosMessageFilter)
   messageFilter?: SubqlCosmosMessageFilter;
+  @IsOptional()
+  @IsObject()
+  attributes?: Record<string, string | number>;
 }
 
 export class CosmosBlockHandler implements SubqlCosmosBlockHandler {

--- a/packages/node/src/utils/cosmos.ts
+++ b/packages/node/src/utils/cosmos.ts
@@ -124,6 +124,17 @@ export function filterEvent(
     return false;
   }
 
+  for (const filterKey in filter.attributes) {
+    if (
+      !event.event.attributes.find(
+        ({ key, value }) =>
+          key === filterKey && value === filter.attributes[filterKey],
+      )
+    ) {
+      return false;
+    }
+  }
+
   return true;
 }
 

--- a/packages/types/src/project.ts
+++ b/packages/types/src/project.ts
@@ -84,6 +84,7 @@ export interface SubqlCosmosMessageFilter extends SubqlCosmosTxFilter {
 export interface SubqlCosmosEventFilter {
   type: string;
   messageFilter?: SubqlCosmosMessageFilter;
+  attributes?: Record<string, string | number>;
 }
 
 export type SubqlCosmosHandlerFilter = SubqlCosmosEventFilter | SubqlCosmosMessageFilter;


### PR DESCRIPTION
# Description
With current filters when user calls contract A, contract A calls contract B, an event happened in contract B,
in this case, B event is only catchable when filter contract A. This is a problem because contract A could be any contract.

This change allows improved filters on events so that it would be possible to filter by events on contract B

## Example

Transaction: https://www.mintscan.io/juno/txs/9B5073521AB7116AE2796073096FEF2F7009E6107F2BF47FBC36F216A0C0C68E

Filter:
```yaml
        - handler: handleEvent
          kind: cosmos/EventHandler
          filter:
            type: execute
            attributes:
              _contract_address: "juno1m7qmz49a9g6zeyzl032aj3rnsu856893cwryx8c4v2gf2s0ewv8qvtcsmx"
            messageFilter:
              type: "/cosmwasm.wasm.v1.MsgExecuteContract"
```

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [x] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
