### PR TITLE
Fix datasource processor sandbox issues

### DIFF
--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -52,7 +52,7 @@
     "sequelize": "6.23.0",
     "tar": "^6.1.11",
     "typescript": "^4.4.4",
-    "vm2": "3.9.9",
+    "vm2": "^3.9.9",
     "yargs": "^16.2.0"
   },
   "devDependencies": {

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -46,7 +46,6 @@ const logger = getLogger('indexer');
 
 @Injectable()
 export class IndexerManager {
-  private api: CosmosClient;
   private filteredDataSources: SubqlProjectDs[];
 
   constructor(
@@ -62,8 +61,6 @@ export class IndexerManager {
     private projectService: ProjectService,
   ) {
     logger.info('indexer manager start');
-
-    this.api = this.apiService.getApi();
   }
 
   @profiler(yargsOptions.argv.profiler)
@@ -181,7 +178,7 @@ export class IndexerManager {
       if (isCustomCosmosDs(ds)) {
         return this.dsProcessorService
           .getDsProcessor(ds)
-          .dsFilterProcessor(ds, this.api);
+          .dsFilterProcessor(ds, this.apiService.getApi());
       } else {
         return true;
       }
@@ -346,7 +343,7 @@ export class IndexerManager {
           return processor.filterProcessor({
             filter: handler.filter,
             input: data,
-            registry: this.api.registry,
+            registry: this.apiService.getApi().registry,
             ds,
           });
         } catch (e) {
@@ -373,7 +370,7 @@ export class IndexerManager {
       .transformer({
         input: data,
         ds,
-        api: this.api,
+        api: this.apiService.getApi(),
         filter: handler.filter,
         assets,
       })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2943,7 +2943,7 @@ __metadata:
     supertest: ^6.1.6
     tar: ^6.1.11
     typescript: ^4.4.4
-    vm2: 3.9.9
+    vm2: ^3.9.9
     yargs: ^16.2.0
   bin:
     subql-node-cosmos: ./bin/run
@@ -11249,18 +11249,6 @@ __metadata:
   version: 1.1.2
   resolution: "vary@npm:1.1.2"
   checksum: ae0123222c6df65b437669d63dfa8c36cee20a504101b2fcd97b8bf76f91259c17f9f2b4d70a1e3c6bbcee7f51b28392833adb6b2770b23b01abec84e369660b
-  languageName: node
-  linkType: hard
-
-"vm2@npm:3.9.9":
-  version: 3.9.9
-  resolution: "vm2@npm:3.9.9"
-  dependencies:
-    acorn: ^8.7.0
-    acorn-walk: ^8.2.0
-  bin:
-    vm2: bin/vm2
-  checksum: ea4859565668918b53cf8c087bc18e2a9506f9f4ef919528707a6fecf50a110a2a8c48bc0c7a754c9d12b97cd16775f005b2b941e99d3a52aadfaac5ce77e04d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description
- Fixes undefined reference to api in indexer.manager
- Fixes registry not being injected into DS processor sandbox
- Fixes vm2 version mismatch
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
