### PR TITLE
support enum looks for proto files

### DIFF
--- a/packages/node/src/indexer/api.service.ts
+++ b/packages/node/src/indexer/api.service.ts
@@ -141,7 +141,7 @@ export class ApiService {
       const pkgName = packageName ?? userPackageName;
       for (const msg of messages) {
         logger.info(`Registering chain message type "/${pkgName}.${msg}"`);
-        const msgObj = network.chainTypes.protoRoot.lookupType(
+        const msgObj = network.chainTypes.protoRoot.lookupTypeOrEnum(
           `${pkgName}.${msg}`,
         );
         res[`/${pkgName}.${msg}`] = msgObj;


### PR DESCRIPTION
# Description
Support Enum lookups from proto files. Currently we only support Type lookups, if a type is dependant on an Enum that is in a different package/file then enum lookup is necessary to successfully register the type.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] My code is up to date with the base branch
