### PR TITLE
expose validator() method from tmClient

### DIFF
--- a/packages/node/src/indexer/api.service.ts
+++ b/packages/node/src/indexer/api.service.ts
@@ -13,7 +13,10 @@ import {
   toRfc3339WithNanoseconds,
   BlockResultsResponse,
 } from '@cosmjs/tendermint-rpc';
-import { BlockResponse } from '@cosmjs/tendermint-rpc/build/tendermint34/responses';
+import {
+  BlockResponse,
+  Validator,
+} from '@cosmjs/tendermint-rpc/build/tendermint34/responses';
 import { Inject, Injectable } from '@nestjs/common';
 import {
   getLogger,
@@ -238,6 +241,14 @@ export class CosmosSafeClient extends CosmWasmClient {
       },
       txs: response.block.txs,
     };
+  }
+
+  async validators(): Promise<readonly Validator[]> {
+    return (
+      await this.forceGetTmClient().validators({
+        height: this.height,
+      })
+    ).validators;
   }
 
   async searchTx(): Promise<readonly IndexedTx[]> {

--- a/packages/types/src/global.ts
+++ b/packages/types/src/global.ts
@@ -4,11 +4,11 @@
 import type {CosmWasmClient} from '@cosmjs/cosmwasm-stargate';
 import type {Registry} from '@cosmjs/proto-signing';
 import type Pino from 'pino';
-import {Store, DynamicDatasourceCreator} from './interfaces';
+import {Store, DynamicDatasourceCreator, CosmWasmSafeClient} from './interfaces';
 
 declare global {
   const apiUnsafe: CosmWasmClient; //requires --unsafe flag to be defined
-  const api: CosmWasmClient;
+  const api: CosmWasmSafeClient;
   const logger: Pino.Logger;
   const store: Store;
   const createDynamicDatasource: DynamicDatasourceCreator;

--- a/packages/types/src/interfaces.ts
+++ b/packages/types/src/interfaces.ts
@@ -1,10 +1,16 @@
 // Copyright 2020-2022 OnFinality Limited authors & contributors
 // SPDX-License-Identifier: Apache-2.0
 
+import {CosmWasmClient} from '@cosmjs/cosmwasm-stargate';
 import {DecodedTxRaw} from '@cosmjs/proto-signing';
 import {Block, Event} from '@cosmjs/stargate';
 import {Log} from '@cosmjs/stargate/build/logs';
 import {TxData, Header} from '@cosmjs/tendermint-rpc';
+import {Validator} from '@cosmjs/tendermint-rpc/build/tendermint34/responses';
+
+export interface CosmWasmSafeClient extends CosmWasmClient {
+  validator(): () => Promise<readonly Validator[]>;
+}
 
 export interface Entity {
   id: string;


### PR DESCRIPTION
# Description
Expose `validator()` from tendermint client to safe api in sandbox. This will allow projects to fetch validators of current block.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] My code is up to date with the base branch
