### PR TITLE
remove axios retries and cleanup logs

### DIFF
--- a/packages/node/src/indexer/api.service.ts
+++ b/packages/node/src/indexer/api.service.ts
@@ -20,7 +20,6 @@ import { Inject, Injectable, OnApplicationShutdown } from '@nestjs/common';
 import {
   getLogger,
   NetworkMetadataPayload,
-  retryOnFailAxios,
   ConnectionPoolService,
   ApiService as BaseApiService,
 } from '@subql/node-core';
@@ -36,7 +35,6 @@ import { BlockContent } from './types';
 const MAX_RECONNECT_ATTEMPTS = 5;
 
 const logger = getLogger('api');
-const RETRY_STATUS_CODES = [429, 502];
 
 @Injectable()
 export class ApiService
@@ -161,10 +159,7 @@ export class ApiService
     return res;
   }
 
-  async fetchBlocks(
-    batch: number[],
-    overallSpecVer?: number,
-  ): Promise<BlockContent[]> {
+  async fetchBlocks(batch: number[]): Promise<BlockContent[]> {
     return this.fetchBlocksGeneric<BlockContent>(
       () => (blockArray: number[]) =>
         this.fetchBlocksBatches(this.api, blockArray),
@@ -193,26 +188,17 @@ export class CosmosClient extends CosmWasmClient {
 
   // eslint-disable-next-line @typescript-eslint/require-await
   async blockInfo(height?: number): Promise<BlockResponse> {
-    return retryOnFailAxios<BlockResponse>(
-      this.tendermintClient.block.bind(this.tendermintClient, height),
-      RETRY_STATUS_CODES,
-    );
+    return this.tendermintClient.block(height);
   }
 
   // eslint-disable-next-line @typescript-eslint/require-await
   async txInfoByHeight(height: number): Promise<readonly IndexedTx[]> {
-    return retryOnFailAxios<IndexedTx[]>(
-      this.searchTx.bind(this, height),
-      RETRY_STATUS_CODES,
-    );
+    return this.searchTx({ height: height });
   }
 
   // eslint-disable-next-line @typescript-eslint/require-await
   async blockResults(height: number): Promise<BlockResultsResponse> {
-    return retryOnFailAxios<BlockResultsResponse>(
-      this.tendermintClient.blockResults.bind(this.tendermintClient, height),
-      RETRY_STATUS_CODES,
-    );
+    return this.tendermintClient.blockResults(height);
   }
 
   decodeMsg<T = unknown>(msg: DecodeObject): T {

--- a/packages/node/src/utils/cosmos.ts
+++ b/packages/node/src/utils/cosmos.ts
@@ -189,14 +189,10 @@ async function getBlockByHeight(
 ): Promise<[BlockResponse, BlockResultsResponse]> {
   return Promise.all([
     api.blockInfo(height).catch((e) => {
-      const error = CosmosClient.handleError(e);
-      logger.error(error, `failed to fetch block info ${height}`);
-      throw error;
+      throw CosmosClient.handleError(e);
     }),
     api.blockResults(height).catch((e) => {
-      const error = CosmosClient.handleError(e);
-      logger.error(error, `failed to fetch block results ${height}`);
-      throw error;
+      throw CosmosClient.handleError(e);
     }),
   ]);
 }


### PR DESCRIPTION
# Description
`retryOnFailAxios` combined with retries from ConnectionPool class will multiply the number of retries. This can be fixed by removing `retryOnFailAxios`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
