### PR TITLE
don't filter messages for begin/end block events

### DIFF
--- a/packages/node/src/utils/cosmos.ts
+++ b/packages/node/src/utils/cosmos.ts
@@ -128,7 +128,7 @@ export function filterEvent(
 
   if (
     filter.messageFilter &&
-    !filterMessageData(event.msg, filter.messageFilter)
+    (!event.msg || !filterMessageData(event.msg, filter.messageFilter))
   ) {
     return false;
   }


### PR DESCRIPTION
# Description
Begin/End block events does not have messages or transactions associated with them. Trying to filter message data in those events will throw error.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
