### PR TITLE
Catch error when event doesn't have a matching messsage

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,11 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Logs with a missing message throwing an error (#156)
 
 ## [2.10.0] - 2023-07-31
 ### Fixed
 - Sync with @node/core, various improvements for POI feature
 - Update license to GPL-3.0 (#152)
+
 ### Changed
 - Sync with node-core :
   - Update node-core and add `store-cache-upper-limit` flag (#144)

--- a/packages/node/src/utils/cosmos.ts
+++ b/packages/node/src/utils/cosmos.ts
@@ -287,7 +287,15 @@ export function wrapEvent(
       continue;
     }
     for (const log of logs) {
-      const msg = wrapCosmosMsg(block, tx, log.msg_index, api);
+      let msg: CosmosMessage;
+      try {
+        msg = wrapCosmosMsg(block, tx, log.msg_index, api);
+      } catch (e) {
+        // Example where this can happen https://sei.explorers.guru/transaction/8D4CA68E917E15652E10CB960DE604AEEB1B183D6E94A85E9CD98403F15550B7
+        logger.warn(
+          `Unable to find message for event. tx=${tx.hash} messageIdx=${log.msg_index}`,
+        );
+      }
       for (let i = 0; i < log.events.length; i++) {
         const event: CosmosEvent = {
           idx: idxOffset++,


### PR DESCRIPTION
# Description
Catches an error and logs a warning when there is an event that doesn't have a messages that matches the message index

Example transaction:
https://sei.explorers.guru/transaction/8D4CA68E917E15652E10CB960DE604AEEB1B183D6E94A85E9CD98403F15550B7

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
