### PR TITLE
stringify object type decoded msg values for filtering

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Adjusted filter function to stringify decoded message data of object types for correct comparison with filters. (#173)
+- Adjusted filter function to stringify decoded message data of Long types for correct comparison with filters. (#173)
 
 ## [2.10.2] - 2023-08-24
 ### Changed

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Adjusted filter function to stringify decoded message data of object types for correct comparison with filters. (#173)
 
 ## [2.10.2] - 2023-08-24
 ### Changed

--- a/packages/node/src/utils/cosmos.spec.ts
+++ b/packages/node/src/utils/cosmos.spec.ts
@@ -199,6 +199,29 @@ describe('CosmosUtils', () => {
     expect(result).toEqual(true);
   });
 
+  it('can filter long type decoded msg for number filter', () => {
+    const msg: CosmosMessage = {
+      tx: null,
+      msg: {
+        typeUrl: '/cosmwasm.wasm.v1.MsgInstantiateContract',
+        decodedMsg: {
+          codeId: longify(4),
+        },
+      },
+    } as unknown as CosmosMessage;
+
+    const filter: CosmosMessageFilter = {
+      type: '/cosmwasm.wasm.v1.MsgInstantiateContract',
+      values: {
+        codeId: 4 as unknown as string,
+      },
+      includeFailedTx: true,
+    };
+
+    const result = filterMessageData(msg, filter);
+    expect(result).toEqual(true);
+  });
+
   it('can filter long type decoded msg for false', () => {
     const msg: CosmosMessage = {
       tx: null,

--- a/packages/node/src/utils/cosmos.spec.ts
+++ b/packages/node/src/utils/cosmos.spec.ts
@@ -8,7 +8,9 @@ import {
   DecodedTxRaw,
 } from '@cosmjs/proto-signing';
 import { defaultRegistryTypes } from '@cosmjs/stargate';
+import { longify } from '@cosmjs/stargate/build/queryclient';
 import { Tendermint37Client } from '@cosmjs/tendermint-rpc';
+import { CosmosMessageFilter } from '@subql/common-cosmos';
 import {
   SubqlCosmosMessageFilter,
   CosmosBlock,
@@ -27,7 +29,7 @@ import { CosmosClient } from '../indexer/api.service';
 import { HttpClient } from '../indexer/rpc-clients';
 import { filterMessageData, wrapEvent } from './cosmos';
 
-const ENDPOINT = 'https://juno.api.onfinality.io/public';
+const ENDPOINT = 'https://rpc-archive.junonetwork.io';
 const CHAINID = 'juno-1';
 
 const TEST_BLOCKNUMBER = 4136538;
@@ -172,5 +174,51 @@ describe('CosmosUtils', () => {
     const spy = jest.spyOn(msg.msg, 'decodedMsg', 'get');
     const result = filterMessageData(msg, TEST_MESSAGE_FILTER_TRUE);
     expect(spy).toHaveBeenCalled();
+  });
+
+  it('can filter long type decoded msg for true', () => {
+    const msg: CosmosMessage = {
+      tx: null,
+      msg: {
+        typeUrl: '/cosmwasm.wasm.v1.MsgInstantiateContract',
+        decodedMsg: {
+          codeId: longify(4),
+        },
+      },
+    } as unknown as CosmosMessage;
+
+    const filter: CosmosMessageFilter = {
+      type: '/cosmwasm.wasm.v1.MsgInstantiateContract',
+      values: {
+        codeId: '4',
+      },
+      includeFailedTx: true,
+    };
+
+    const result = filterMessageData(msg, filter);
+    expect(result).toEqual(true);
+  });
+
+  it('can filter long type decoded msg for false', () => {
+    const msg: CosmosMessage = {
+      tx: null,
+      msg: {
+        typeUrl: '/cosmwasm.wasm.v1.MsgInstantiateContract',
+        decodedMsg: {
+          codeId: longify(4),
+        },
+      },
+    } as unknown as CosmosMessage;
+
+    const filter: CosmosMessageFilter = {
+      type: '/cosmwasm.wasm.v1.MsgInstantiateContract',
+      values: {
+        codeId: '5',
+      },
+      includeFailedTx: true,
+    };
+
+    const result = filterMessageData(msg, filter);
+    expect(result).toEqual(false);
   });
 });

--- a/packages/node/src/utils/cosmos.ts
+++ b/packages/node/src/utils/cosmos.ts
@@ -69,10 +69,16 @@ export function filterMessageData(
   }
   if (filter.values) {
     for (const key in filter.values) {
-      if (
-        filter.values[key] !==
-        key.split('.').reduce((acc, curr) => acc[curr], data.msg.decodedMsg)
-      ) {
+      let decodedMsgData = key
+        .split('.')
+        .reduce((acc, curr) => acc[curr], data.msg.decodedMsg);
+
+      //stringify object types (such as Long) for equality check
+      if (typeof decodedMsgData === 'object') {
+        decodedMsgData = decodedMsgData.toString();
+      }
+
+      if (filter.values[key] !== decodedMsgData) {
         return false;
       }
     }

--- a/packages/node/src/utils/cosmos.ts
+++ b/packages/node/src/utils/cosmos.ts
@@ -76,7 +76,10 @@ export function filterMessageData(
 
       //stringify Long for equality check
       if (isLong(decodedMsgData)) {
-        decodedMsgData = decodedMsgData.toString();
+        decodedMsgData =
+          typeof filter.values[key] === 'number'
+            ? decodedMsgData.toNumber()
+            : decodedMsgData.toString();
       }
 
       if (filter.values[key] !== decodedMsgData) {

--- a/packages/node/src/utils/cosmos.ts
+++ b/packages/node/src/utils/cosmos.ts
@@ -24,6 +24,7 @@ import {
   SubqlCosmosBlockFilter,
   SubqlCosmosTxFilter,
 } from '@subql/types-cosmos';
+import { isLong } from 'long';
 import { CosmosClient } from '../indexer/api.service';
 import { BlockContent } from '../indexer/types';
 
@@ -73,8 +74,8 @@ export function filterMessageData(
         .split('.')
         .reduce((acc, curr) => acc[curr], data.msg.decodedMsg);
 
-      //stringify object types (such as Long) for equality check
-      if (typeof decodedMsgData === 'object') {
+      //stringify Long for equality check
+      if (isLong(decodedMsgData)) {
         decodedMsgData = decodedMsgData.toString();
       }
 


### PR DESCRIPTION
# Description
User can only specify string or number values under filter in yaml manifests. If the decoded message values are of object types (such as Long), stringify them to compare it with filter values. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
