### PR TITLE
force exit jest after test completion

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "test": "jest --coverage",
     "test:all": "node --expose-gc ./node_modules/.bin/jest --logHeapUsage --testRegex='.*\\.(spec|test)\\.ts$' --forceExit --ci -w=2 --clearMocks",
     "test:docker": "docker-compose -f test/docker-compose.yaml up --remove-orphans --abort-on-container-exit --build test",
-    "test-jest": "jest --testRegex='.*\\.(spec|test)\\.ts$'",
+    "test-jest": "jest --testRegex='.*\\.(spec|test)\\.ts$' --forceExit",
     "postinstall": "husky install"
   },
   "lint-staged": {

--- a/packages/common-cosmos/src/codegen/codegen-controller.spec.ts
+++ b/packages/common-cosmos/src/codegen/codegen-controller.spec.ts
@@ -120,9 +120,7 @@ describe('Codegen cosmos', () => {
           ],
         },
       } as SubqlCosmosRuntimeDatasource;
-      const expectedOutput = new Map<string, string>([
-        ['cw20', path.join(PROJECT_PATH, 'cosmwasm-contract/cw20/schema/cw20.json')],
-      ]);
+      const expectedOutput = {cw20: path.join(PROJECT_PATH, 'cosmwasm-contract/cw20/schema/cw20.json')};
 
       expect(prepareSortedAssets([cosmosDs], PROJECT_PATH)).toStrictEqual(expectedOutput);
     });

--- a/packages/node/src/utils/cosmos.spec.ts
+++ b/packages/node/src/utils/cosmos.spec.ts
@@ -244,4 +244,8 @@ describe('CosmosUtils', () => {
     const result = filterMessageData(msg, filter);
     expect(result).toEqual(false);
   });
+
+  afterEach(() => {
+    api.disconnect();
+  });
 });


### PR DESCRIPTION
# Description
CI gets stuck as jest does not exit after tests due to open handles. force exit jest after tests are completed

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
