### PR TITLE
updated all chainTypes to chaintypes

### DIFF
--- a/packages/common-cosmos/CHANGELOG.md
+++ b/packages/common-cosmos/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed Missing chainTypes on deployment (#175)
 
+### Changed
+- Updated NetworkConfig to use `chaintypes` instead of `chainTypes`
+
 ## [2.5.1] - 2023-09-20
 ### Changed
 - Downgrade `subql/common` due to breaking changes (#176)

--- a/packages/common-cosmos/CHANGELOG.md
+++ b/packages/common-cosmos/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Missing chainTypes on deployment (#175)
 
 ### Changed
-- Updated NetworkConfig to use `chaintypes` instead of `chainTypes`
+- Updated NetworkConfig to use `chaintypes` instead of `chainTypes` (#180)
 
 ## [2.5.1] - 2023-09-20
 ### Changed

--- a/packages/common-cosmos/src/codegen/codegen-controller.ts
+++ b/packages/common-cosmos/src/codegen/codegen-controller.ts
@@ -6,7 +6,7 @@ import path from 'path';
 import telescope from '@cosmology/telescope';
 import cosmwasmCodegen from '@cosmwasm/ts-codegen';
 import {makeTempDir} from '@subql/common';
-import {CosmosChainTypes, CustomModule, SubqlCosmosRuntimeDatasource} from '@subql/types-cosmos';
+import {CosmosChaintypes, CustomModule, SubqlCosmosRuntimeDatasource} from '@subql/types-cosmos';
 import {Data} from 'ejs';
 import {copySync} from 'fs-extra';
 import {IDLObject} from 'wasm-ast-types';
@@ -29,7 +29,7 @@ interface ProtobufRenderProps {
   messageNames: string[]; // all messages
   path: string; // should process the file Path and concat with PROTO dir
 }
-type CosmosChainTypeDataType = CosmosChainTypes | Record<string, CustomModule>;
+type CosmosChainTypeDataType = CosmosChaintypes | Record<string, CustomModule>;
 
 interface CosmwasmRenderJobType {
   contract: string;
@@ -144,14 +144,14 @@ export async function generateCosmwasm(
 }
 
 export function prepareProtobufRenderProps(
-  chainTypes: (CosmosChainTypeDataType | undefined)[] | undefined,
+  chaintypes: (CosmosChainTypeDataType | undefined)[] | undefined,
   projectPath: string
 ): ProtobufRenderProps[] {
-  if (!chainTypes) {
+  if (!chaintypes) {
     return [];
   }
-  return chainTypes.filter(Boolean).flatMap((chainType) => {
-    return Object.entries(chainType).map(([key, value]) => {
+  return chaintypes.filter(Boolean).flatMap((chaintype) => {
+    return Object.entries(chaintype).map(([key, value]) => {
       const filePath = path.join(projectPath, value.file);
       if (!fs.existsSync(filePath)) {
         throw new Error(`Error: chainType ${key}, file ${value.file} does not exist`);
@@ -193,7 +193,7 @@ export async function tempProtoDir(projectPath: string): Promise<string> {
 }
 
 export async function generateProto(
-  chainTypes: CosmosChainTypeDataType[],
+  chaintypes: CosmosChainTypeDataType[],
   projectPath: string,
   prepareDirPath: (path: string, recreate: boolean) => Promise<void>,
   renderTemplate: (templatePath: string, outputPath: string, templateData: Data) => Promise<void>,
@@ -203,7 +203,7 @@ export async function generateProto(
   let tmpPath: string;
   try {
     tmpPath = await mkdirProto(projectPath);
-    const protobufRenderProps = prepareProtobufRenderProps(chainTypes, projectPath);
+    const protobufRenderProps = prepareProtobufRenderProps(chaintypes, projectPath);
     const outputPath = path.join(projectPath, PROTO_INTERFACES_ROOT_DIR);
     await prepareDirPath(path.join(projectPath, PROTO_INTERFACES_ROOT_DIR), true);
 

--- a/packages/common-cosmos/src/project/project.spec.ts
+++ b/packages/common-cosmos/src/project/project.spec.ts
@@ -46,9 +46,9 @@ describe('project.yaml', () => {
     ) as any;
     expect(() => parseCosmosProjectManifest(cosmosManifest)).toThrow('failed to parse project.yaml');
   });
-  it('Ensure chainTypes existence on manifest deployment', () => {
+  it('Ensure chaintypes existence on manifest deployment', () => {
     const cosmosManifest = loadFromJsonOrYaml(path.join(projectsDir, './protoTest1', 'project.yaml')) as any;
     const manifest = parseCosmosProjectManifest(cosmosManifest);
-    expect(manifest.asImpl.network.chainTypes.size).toBeGreaterThan(0);
+    expect(manifest.asImpl.network.chaintypes.size).toBeGreaterThan(0);
   });
 });

--- a/packages/common-cosmos/src/project/types.ts
+++ b/packages/common-cosmos/src/project/types.ts
@@ -34,5 +34,5 @@ export type CosmosChainType = CustomModule & {
 
 export type CosmosProjectNetConfig = CosmosProjectNetworkConfig & {
   chainId: string;
-  chainTypes: Map<string, CosmosChainType> & {protoRoot: protobuf.Root};
+  chaintypes: Map<string, CosmosChainType> & {protoRoot: protobuf.Root};
 };

--- a/packages/common-cosmos/src/project/versioned/v1_0_0/model.ts
+++ b/packages/common-cosmos/src/project/versioned/v1_0_0/model.ts
@@ -21,7 +21,7 @@ import {
   RuntimeDatasourceTemplate,
   CustomDatasourceTemplate,
   CosmosProjectManifestV1_0_0,
-  CosmosChainTypes,
+  CosmosChaintypes,
 } from '@subql/types-cosmos';
 import {Transform, TransformFnParams, Type} from 'class-transformer';
 import {Equals, IsObject, IsString, ValidateNested, IsOptional, IsArray, IsNotEmpty} from 'class-validator';
@@ -66,14 +66,14 @@ export class CosmosProjectNetworkDeployment {
   @IsOptional()
   @Type(() => CosmosCustomModuleImpl)
   @ValidateNested({each: true})
-  chainTypes?: Map<string, CosmosCustomModuleImpl>;
+  chaintypes?: Map<string, CosmosCustomModuleImpl>;
 }
 
-export class CosmosProjectNetwork extends CommonProjectNetworkV1_0_0<CosmosChainTypes> {
+export class CosmosProjectNetwork extends CommonProjectNetworkV1_0_0<CosmosChaintypes> {
   @Type(() => CosmosCustomModuleImpl)
   @IsOptional()
   @ValidateNested({each: true})
-  chainTypes?: Map<string, CosmosCustomModuleImpl>;
+  chaintypes?: Map<string, CosmosCustomModuleImpl>;
 }
 
 export class RuntimeDatasourceTemplateImpl extends CosmosRuntimeDataSourceImpl implements RuntimeDatasourceTemplate {

--- a/packages/common-cosmos/test/protoTest1/bad-chaintypes-project.yaml
+++ b/packages/common-cosmos/test/protoTest1/bad-chaintypes-project.yaml
@@ -17,7 +17,7 @@ network:
   endpoint:
     - https://osmosis.api.onfinality.io/public
   dictionary: 'https://api.subquery.network/sq/subquery/cosmos-osmosis-dictionary'
-  chainTypes:
+  chaintypes:
     osmosis.gamm.v1beta1:
       filePath: './proto/osmosis/gamm/v1beta1/tx.proto'
       message:

--- a/packages/common-cosmos/test/protoTest1/project.yaml
+++ b/packages/common-cosmos/test/protoTest1/project.yaml
@@ -17,7 +17,7 @@ network:
   endpoint:
     - https://osmosis.api.onfinality.io/public
   dictionary: 'https://api.subquery.network/sq/subquery/cosmos-osmosis-dictionary'
-  chainTypes:
+  chaintypes:
     osmosis.gamm.v1beta1:
       file: './proto/osmosis/gamm/v1beta1/tx.proto'
       messages:

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- Updated NetworkConfig to use `chaintypes` instead of `chainTypes`
+- Updated NetworkConfig to use `chaintypes` instead of `chainTypes` (#180)
 
 ## [2.10.3] - 2023-09-20
 ### Changed

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Updated NetworkConfig to use `chaintypes` instead of `chainTypes`
 
 ## [2.10.3] - 2023-09-20
 ### Changed

--- a/packages/node/src/indexer/api.service.ts
+++ b/packages/node/src/indexer/api.service.ts
@@ -57,7 +57,7 @@ export class ApiService
   }
 
   private async buildRegistry(): Promise<Registry> {
-    const chainTypes = await this.getChainType(this.project.network);
+    const chaintypes = await this.getChainType(this.project.network);
 
     const wasmTypes: ReadonlyArray<[string, GeneratedType]> = [
       ['/cosmwasm.wasm.v1.MsgClearAdmin', MsgClearAdmin],
@@ -70,8 +70,8 @@ export class ApiService
 
     const registry = new Registry([...defaultRegistryTypes, ...wasmTypes]);
 
-    for (const typeurl in chainTypes) {
-      registry.register(typeurl, chainTypes[typeurl]);
+    for (const typeurl in chaintypes) {
+      registry.register(typeurl, chaintypes[typeurl]);
     }
 
     return registry;
@@ -116,7 +116,7 @@ export class ApiService
   async getChainType(
     network: Partial<CosmosProjectNetConfig>,
   ): Promise<Record<string, GeneratedType>> {
-    if (!network.chainTypes) {
+    if (!network.chaintypes) {
       return {};
     }
 
@@ -124,11 +124,11 @@ export class ApiService
     for (const [
       userPackageName,
       { messages, packageName },
-    ] of network.chainTypes) {
+    ] of network.chaintypes) {
       const pkgName = packageName ?? userPackageName;
       for (const msg of messages) {
         logger.info(`Registering chain message type "/${pkgName}.${msg}"`);
-        const msgObj = network.chainTypes.protoRoot.lookupTypeOrEnum(
+        const msgObj = network.chaintypes.protoRoot.lookupTypeOrEnum(
           `${pkgName}.${msg}`,
         );
         res[`/${pkgName}.${msg}`] = msgObj;

--- a/packages/node/src/utils/project.ts
+++ b/packages/node/src/utils/project.ts
@@ -35,24 +35,24 @@ export async function processNetworkConfig(
   }
   delete network.genesisHash;
 
-  const chainTypes = new Map<string, CosmosChainType>() as Map<
+  const chaintypes = new Map<string, CosmosChainType>() as Map<
     string,
     CosmosChainType
   > & { protoRoot: protobuf.Root };
-  if (!network.chainTypes) {
-    network.chainTypes = chainTypes;
+  if (!network.chaintypes) {
+    network.chaintypes = chaintypes;
     return network;
   }
 
   const protoRoot = new protobuf.Root();
-  for (const [key, value] of network.chainTypes) {
+  for (const [key, value] of network.chaintypes) {
     const [packageName, proto] = await loadNetworkChainType(reader, value.file);
-    chainTypes.set(key, { ...value, packageName, proto });
+    chaintypes.set(key, { ...value, packageName, proto });
 
     protoRoot.add(proto);
   }
-  chainTypes.protoRoot = protoRoot;
-  network.chainTypes = chainTypes;
+  chaintypes.protoRoot = protoRoot;
+  network.chaintypes = chaintypes;
   return network;
 }
 

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Added `cosmwasm` messages types (#168)
+### Changed
+- Updated NetworkConfig to use `chaintypes` instead of `chainTypes`
 
 ## [2.2.1] - 2023-07-31
 ### Changed

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added `cosmwasm` messages types (#168)
 ### Changed
-- Updated NetworkConfig to use `chaintypes` instead of `chainTypes`
+- Updated NetworkConfig to use `chaintypes` instead of `chainTypes` (#180)
 
 ## [2.2.1] - 2023-07-31
 ### Changed

--- a/packages/types/src/project.ts
+++ b/packages/types/src/project.ts
@@ -37,7 +37,7 @@ export interface CustomModule extends FileReference {
   messages: string[];
 }
 
-export type CosmosChainTypes = Map<string, CustomModule>;
+export type CosmosChaintypes = Map<string, CustomModule>;
 
 export type CustomDataSourceAsset = FileReference;
 
@@ -93,7 +93,7 @@ export type CosmosNetworkConfig = IProjectNetworkConfig & {
    * If filters do not pick up these message types they don't need to be added.
    * The key needs to be a unique value, it's good to have the same key as the package but if there are multiple files with the same package then change the name.
    * @example
-   * chainTypes: {
+   * chaintypes: {
       ethermint.evm.v1: {
         file: "./proto/ethermint/evm/v1/tx.proto",
         messages: [
@@ -105,7 +105,7 @@ export type CosmosNetworkConfig = IProjectNetworkConfig & {
       }
     }
    * */
-  chainTypes?: CosmosChainTypes;
+  chaintypes?: CosmosChaintypes;
 };
 
 export type SubqlCosmosBlockFilter = BlockFilter;


### PR DESCRIPTION
# Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Instead of https://github.com/subquery/subql/pull/2069/files
`chainTypes` is considered as typo instead of `chaintypes`
