### PR TITLE
check if contractCall msg is Object before using `in` operator

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix contractCall filtering issue on non-object calls (#188)
 
 ## [3.0.2] - 2023-10-12
 ### Changed

--- a/packages/node/src/utils/cosmos.spec.ts
+++ b/packages/node/src/utils/cosmos.spec.ts
@@ -245,6 +245,92 @@ describe('CosmosUtils', () => {
     expect(result).toEqual(false);
   });
 
+  describe('filterMessageData function', () => {
+    const baseData = {
+      tx: {
+        tx: {
+          code: 0,
+        },
+      },
+      msg: {
+        typeUrl: '/cosmwasm.wasm.v1.MsgExecuteContract',
+        decodedMsg: {
+          msg: {},
+        },
+      },
+    } as unknown as CosmosMessage;
+
+    describe('contractCall filtering', () => {
+      it('should return true for non-object contractCall in msg', () => {
+        const data = {
+          ...baseData,
+          msg: {
+            ...baseData.msg,
+            decodedMsg: {
+              msg: 'nonObjectContractCall',
+            },
+          },
+        };
+        const filter = {
+          type: '/cosmwasm.wasm.v1.MsgExecuteContract',
+          contractCall: 'nonObjectContractCall',
+        };
+
+        const result = filterMessageData(data, filter);
+        expect(result).toBe(true);
+      });
+
+      it('should return false for non-object contractCall not in msg', () => {
+        const data = {
+          ...baseData,
+          msg: {
+            ...baseData.msg,
+            decodedMsg: {
+              msg: 'nonObjectContractCall2',
+            },
+          },
+        };
+        const filter = {
+          type: '/cosmwasm.wasm.v1.MsgExecuteContract',
+          contractCall: 'nonObjectContractCall',
+        };
+
+        const result = filterMessageData(data, filter);
+        expect(result).toBe(false);
+      });
+
+      it('should return false for object contractCall not in msg', () => {
+        const filter = {
+          type: '/cosmwasm.wasm.v1.MsgExecuteContract',
+          contractCall: 'notInMsg',
+        };
+
+        const result = filterMessageData(baseData, filter);
+        expect(result).toBe(false);
+      });
+
+      it('should return true for object contractCall in msg', () => {
+        const contractCall = { inMsg: 'inMsg' };
+        const data = {
+          ...baseData,
+          msg: {
+            ...baseData.msg,
+            decodedMsg: {
+              msg: contractCall,
+            },
+          },
+        };
+        const filter = {
+          type: '/cosmwasm.wasm.v1.MsgExecuteContract',
+          contractCall: 'inMsg',
+        };
+
+        const result = filterMessageData(data, filter);
+        expect(result).toBe(true);
+      });
+    });
+  });
+
   afterEach(() => {
     api.disconnect();
   });

--- a/packages/node/src/utils/cosmos.ts
+++ b/packages/node/src/utils/cosmos.ts
@@ -24,6 +24,7 @@ import {
   SubqlCosmosBlockFilter,
   SubqlCosmosTxFilter,
 } from '@subql/types-cosmos';
+import { isObjectLike } from 'lodash';
 import { isLong } from 'long';
 import { CosmosClient } from '../indexer/api.service';
 import { BlockContent } from '../indexer/types';
@@ -87,12 +88,14 @@ export function filterMessageData(
       }
     }
   }
+  console.log(data.msg.decodedMsg.msg);
   if (
     filter.type === '/cosmwasm.wasm.v1.MsgExecuteContract' &&
     filter.contractCall &&
     !(
       filter.contractCall === data.msg.decodedMsg.msg ||
-      filter.contractCall in data.msg.decodedMsg.msg
+      (isObjectLike(data.msg.decodedMsg.msg) &&
+        filter.contractCall in data.msg.decodedMsg.msg)
     )
   ) {
     return false;

--- a/packages/node/src/utils/cosmos.ts
+++ b/packages/node/src/utils/cosmos.ts
@@ -88,7 +88,6 @@ export function filterMessageData(
       }
     }
   }
-  console.log(data.msg.decodedMsg.msg);
   if (
     filter.type === '/cosmwasm.wasm.v1.MsgExecuteContract' &&
     filter.contractCall &&


### PR DESCRIPTION
# Description
check if it is safe to use `in` operator on decoded contract call msg data before trying to match it with contractCall filter using `in` operator

Fixes #185 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
