### PR TITLE
Fix `TypeError: Cannot read properties of null (reading 'hash')`

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Reading `null` on first block (#204)
 
 ## [3.3.0] - 2023-11-06
 ### Added

--- a/packages/node/src/indexer/worker/worker.service.ts
+++ b/packages/node/src/indexer/worker/worker.service.ts
@@ -18,7 +18,7 @@ import { IndexerManager } from '../indexer.manager';
 import { BlockContent } from '../types';
 
 export type FetchBlockResponse = {
-  parentHash: string | null;
+  parentHash: string | undefined;
 };
 
 export type WorkerStatusResponse = {

--- a/packages/node/src/indexer/worker/worker.service.ts
+++ b/packages/node/src/indexer/worker/worker.service.ts
@@ -18,7 +18,7 @@ import { IndexerManager } from '../indexer.manager';
 import { BlockContent } from '../types';
 
 export type FetchBlockResponse = {
-  parentHash: string;
+  parentHash: string | null;
 };
 
 export type WorkerStatusResponse = {

--- a/packages/node/src/indexer/worker/worker.service.ts
+++ b/packages/node/src/indexer/worker/worker.service.ts
@@ -59,7 +59,7 @@ export class WorkerService extends BaseWorkerService<
 
   protected toBlockResponse(block: BlockContent): FetchBlockResponse {
     return {
-      parentHash: block.block.header.lastBlockId.hash.toString(),
+      parentHash: block.block.header.lastBlockId?.hash.toString(),
     };
   }
 


### PR DESCRIPTION
# Description
Fix for 
```
2023-11-07T23:07:43.548Z <Worker Service #1-#1> ERROR Failed to fetch block 5300201 TypeError: Cannot read properties of null (reading 'hash')
```
According to Tendermint rpc types `Block ID of the previous block. This can be null when the currect block is height 1.` 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
