### PR TITLE
Fix websocket client adding `/websocket` to the end of urls

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `/websocket` being appended to all websocket urls causing the indexer to hang (#222)
 
 ## [3.4.6] - 2023-12-25
 ### Fixed

--- a/packages/node/src/indexer/rpc-clients/WebsocketClient.ts
+++ b/packages/node/src/indexer/rpc-clients/WebsocketClient.ts
@@ -192,15 +192,7 @@ export class WebsocketClient implements RpcStreamingClient {
     baseUrl: string,
     onError: (err: any) => void = defaultErrorHandler,
   ) {
-    // accept host.name:port and assume ws protocol
-
     const url = new URL(baseUrl);
-
-    // Add websocket to pathname
-    if (!url.pathname.includes('websocket')) {
-      // make sure we don't end up with ...//websocket
-      url.pathname += url.pathname.endsWith('/') ? 'websocket' : '/websocket';
-    }
 
     // Ensure protocol
     if (!hasProtocol(baseUrl)) {


### PR DESCRIPTION
# Description
I'm unsure why this code was here in the first place.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
