### PR TITLE
fix missing filter codeId in long type

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Bring back `long` to fix missing filter `codeId` in long type
+
 ## [3.11.1] - 2024-05-02
 ### Fixed
 - Sandbox Uint8Array and missing pg dep issue

--- a/packages/node/src/utils/cosmos.spec.ts
+++ b/packages/node/src/utils/cosmos.spec.ts
@@ -23,6 +23,7 @@ import {
   MsgStoreCode,
   MsgUpdateAdmin,
 } from 'cosmjs-types/cosmwasm/wasm/v1/tx';
+import { isLong, fromInt } from 'long';
 import { CosmosClient } from '../indexer/api.service';
 import { HttpClient } from '../indexer/rpc-clients';
 import { decodeMsg, filterMessageData, wrapEvent } from './cosmos';
@@ -173,74 +174,74 @@ describe('CosmosUtils', () => {
     expect(spy).toHaveBeenCalled();
   });
 
-  // it('can filter long type decoded msg for true', () => {
-  //   const msg: CosmosMessage = {
-  //     tx: null,
-  //     msg: {
-  //       typeUrl: '/cosmwasm.wasm.v1.MsgInstantiateContract',
-  //       decodedMsg: {
-  //         codeId: longify(4),
-  //       },
-  //     },
-  //   } as unknown as CosmosMessage;
+  it('can filter long type decoded msg for true', () => {
+    const msg: CosmosMessage = {
+      tx: null,
+      msg: {
+        typeUrl: '/cosmwasm.wasm.v1.MsgInstantiateContract',
+        decodedMsg: {
+          codeId: fromInt(4),
+        },
+      },
+    } as unknown as CosmosMessage;
 
-  //   const filter: CosmosMessageFilter = {
-  //     type: '/cosmwasm.wasm.v1.MsgInstantiateContract',
-  //     values: {
-  //       codeId: '4',
-  //     },
-  //     includeFailedTx: true,
-  //   };
+    const filter: CosmosMessageFilter = {
+      type: '/cosmwasm.wasm.v1.MsgInstantiateContract',
+      values: {
+        codeId: '4',
+      },
+      includeFailedTx: true,
+    };
 
-  //   const result = filterMessageData(msg, filter);
-  //   expect(result).toEqual(true);
-  // });
+    const result = filterMessageData(msg, filter);
+    expect(result).toEqual(true);
+  });
 
-  // it('can filter long type decoded msg for number filter', () => {
-  //   const msg: CosmosMessage = {
-  //     tx: null,
-  //     msg: {
-  //       typeUrl: '/cosmwasm.wasm.v1.MsgInstantiateContract',
-  //       decodedMsg: {
-  //         codeId: longify(4),
-  //       },
-  //     },
-  //   } as unknown as CosmosMessage;
+  it('can filter long type decoded msg for number filter', () => {
+    const msg: CosmosMessage = {
+      tx: null,
+      msg: {
+        typeUrl: '/cosmwasm.wasm.v1.MsgInstantiateContract',
+        decodedMsg: {
+          codeId: fromInt(4),
+        },
+      },
+    } as unknown as CosmosMessage;
 
-  //   const filter: CosmosMessageFilter = {
-  //     type: '/cosmwasm.wasm.v1.MsgInstantiateContract',
-  //     values: {
-  //       codeId: 4 as unknown as string,
-  //     },
-  //     includeFailedTx: true,
-  //   };
+    const filter: CosmosMessageFilter = {
+      type: '/cosmwasm.wasm.v1.MsgInstantiateContract',
+      values: {
+        codeId: 4 as unknown as string,
+      },
+      includeFailedTx: true,
+    };
 
-  //   const result = filterMessageData(msg, filter);
-  //   expect(result).toEqual(true);
-  // });
+    const result = filterMessageData(msg, filter);
+    expect(result).toEqual(true);
+  });
 
-  // it('can filter long type decoded msg for false', () => {
-  //   const msg: CosmosMessage = {
-  //     tx: null,
-  //     msg: {
-  //       typeUrl: '/cosmwasm.wasm.v1.MsgInstantiateContract',
-  //       decodedMsg: {
-  //         codeId: longify(4),
-  //       },
-  //     },
-  //   } as unknown as CosmosMessage;
+  it('can filter long type decoded msg for false', () => {
+    const msg: CosmosMessage = {
+      tx: null,
+      msg: {
+        typeUrl: '/cosmwasm.wasm.v1.MsgInstantiateContract',
+        decodedMsg: {
+          codeId: fromInt(4),
+        },
+      },
+    } as unknown as CosmosMessage;
 
-  //   const filter: CosmosMessageFilter = {
-  //     type: '/cosmwasm.wasm.v1.MsgInstantiateContract',
-  //     values: {
-  //       codeId: '5',
-  //     },
-  //     includeFailedTx: true,
-  //   };
+    const filter: CosmosMessageFilter = {
+      type: '/cosmwasm.wasm.v1.MsgInstantiateContract',
+      values: {
+        codeId: '5',
+      },
+      includeFailedTx: true,
+    };
 
-  //   const result = filterMessageData(msg, filter);
-  //   expect(result).toEqual(false);
-  // });
+    const result = filterMessageData(msg, filter);
+    expect(result).toEqual(false);
+  });
 
   describe('filterMessageData function', () => {
     const baseData = {

--- a/packages/node/src/utils/cosmos.ts
+++ b/packages/node/src/utils/cosmos.ts
@@ -33,6 +33,7 @@ import {
   CosmosTxFilter,
 } from '@subql/types-cosmos';
 import { isObjectLike } from 'lodash';
+import { isLong } from 'long';
 import { SubqlProjectBlockFilter } from '../configure/SubqueryProject';
 import { CosmosClient } from '../indexer/api.service';
 import { BlockContent } from '../indexer/types';
@@ -113,10 +114,17 @@ export function filterMessageData(
   }
   if (filter.values) {
     for (const key in filter.values) {
-      const decodedMsgData = key
+      let decodedMsgData = key
         .split('.')
         .reduce((acc, curr) => acc[curr], data.msg.decodedMsg);
 
+      //stringify Long for equality check
+      if (isLong(decodedMsgData)) {
+        decodedMsgData =
+          typeof filter.values[key] === 'number'
+            ? decodedMsgData.toNumber()
+            : decodedMsgData.toString();
+      }
       if (filter.values[key] !== decodedMsgData) {
         return false;
       }


### PR DESCRIPTION
# Description
Background: cosmosjs deprecated long for message.callId in 0.32.0 https://github.com/cosmos/cosmjs/blob/main/CHANGELOG.md#changed-2. We made change to remove it in previous pr https://github.com/subquery/subql-cosmos/commit/ac68f61a7c4afb54a166ea3b759ac73e6de8b315#diff-7ed3b4e1e7a4809a4c839b761afb2eb1a0c45c6b5dd0f01c9cdb520cb80a015bL78.

From v3.11.0, We now facing any issue message filter not able to filter callId and handlers are not triggered. 
In this fix, we temp bring back `long` for message.callId, due to we have multiple version of `@cosmjs/stargate` installed in our sdk, and older version were installed from dependency `@kyvejs/xxx`. Use resolution in package.json also could not fixed version for `@cosmjs/stargate`.

Fixes # (issue)

We shall remove `long` again once `@kyvejs/xxx` update dependencies `@cosmjs/stargate` to 0.32.0 or above.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [ ] I have performed a self review of my changes
- [ ] Updated any relevant documentation
- [ ] Linked to any relevant issues
- [ ] I have added tests relevant to my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
