### PR TITLE
Add PostIndex Handler Support and Enhance CosmosEvent with Event Source Context

### DIFF
--- a/packages/common-cosmos/src/project/models.ts
+++ b/packages/common-cosmos/src/project/models.ts
@@ -23,6 +23,9 @@ import {
   CustomModule,
   CosmosTxFilter,
   CosmosPostIndexBlockHandler,
+  BatchCosmosTransactionHandler,
+  BatchCosmosMessageHandler,
+  BatchCosmosEventHandler,
 } from '@subql/types-cosmos';
 import {plainToClass, Transform, Type} from 'class-transformer';
 import {
@@ -116,6 +119,35 @@ export class EventHandler implements CosmosEventHandler {
   handler!: string;
 }
 
+export class BatchTransactionHandler implements BatchCosmosTransactionHandler {
+  @IsEnum(CosmosHandlerKind, {groups: [CosmosHandlerKind.BatchTransaction]})
+  kind!: CosmosHandlerKind.BatchTransaction;
+  @IsString()
+  handler!: string;
+}
+
+export class BatchMessageHandler implements BatchCosmosMessageHandler {
+  @IsEnum(CosmosHandlerKind, {groups: [CosmosHandlerKind.BatchMessage]})
+  kind!: CosmosHandlerKind.BatchMessage;
+  @IsString()
+  handler!: string;
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => MessageFilter)
+  filter?: CosmosMessageFilter;
+}
+
+export class BatchEventHandler implements BatchCosmosEventHandler {
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => EventFilter)
+  filter?: CosmosEventFilter;
+  @IsEnum(CosmosHandlerKind, {groups: [CosmosHandlerKind.BatchEvent]})
+  kind!: CosmosHandlerKind.BatchEvent;
+  @IsString()
+  handler!: string;
+}
+
 export class PostIndexHandler implements CosmosPostIndexBlockHandler {
   @IsEnum(CosmosHandlerKind, {groups: [CosmosHandlerKind.PostIndex]})
   kind!: CosmosHandlerKind.PostIndex;
@@ -151,6 +183,12 @@ export class RuntimeMapping implements CosmosMapping {
           return plainToClass(BlockHandler, handler);
         case CosmosHandlerKind.PostIndex:
           return plainToClass(PostIndexHandler, handler);
+        case CosmosHandlerKind.BatchTransaction:
+          return plainToClass(BatchTransactionHandler, handler);
+        case CosmosHandlerKind.BatchEvent:
+          return plainToClass(BatchEventHandler, handler);
+        case CosmosHandlerKind.BatchMessage:
+          return plainToClass(BatchMessageHandler, handler);
         default:
           throw new Error(`handler ${(handler as any).kind} not supported`);
       }

--- a/packages/common-cosmos/src/project/models.ts
+++ b/packages/common-cosmos/src/project/models.ts
@@ -22,6 +22,7 @@ import {
   CosmosMessageHandler,
   CustomModule,
   CosmosTxFilter,
+  CosmosPostIndexBlockHandler,
 } from '@subql/types-cosmos';
 import {plainToClass, Transform, Type} from 'class-transformer';
 import {
@@ -115,6 +116,16 @@ export class EventHandler implements CosmosEventHandler {
   handler!: string;
 }
 
+export class PostIndexHandler implements CosmosPostIndexBlockHandler {
+  @IsEnum(CosmosHandlerKind, {groups: [CosmosHandlerKind.PostIndex]})
+  kind!: CosmosHandlerKind.PostIndex;
+  @IsString()
+  handler!: string;
+  @IsOptional()
+  @Type(() => BlockFilter)
+  filter?: CosmosBlockFilter;
+}
+
 export class CustomHandler implements CosmosCustomHandler {
   @IsString()
   kind!: string;
@@ -138,6 +149,8 @@ export class RuntimeMapping implements CosmosMapping {
           return plainToClass(TransactionHandler, handler);
         case CosmosHandlerKind.Block:
           return plainToClass(BlockHandler, handler);
+        case CosmosHandlerKind.PostIndex:
+          return plainToClass(PostIndexHandler, handler);
         default:
           throw new Error(`handler ${(handler as any).kind} not supported`);
       }

--- a/packages/common-cosmos/src/project/utils.ts
+++ b/packages/common-cosmos/src/project/utils.ts
@@ -60,6 +60,24 @@ export function isPostIndexHandlerProcessor<E>(
   return hp.baseHandlerKind === CosmosHandlerKind.PostIndex;
 }
 
+export function isBatchEventHandlerProcessor<E>(
+  hp: SecondLayerHandlerProcessorArray<CosmosHandlerKind, DefaultFilter, unknown>
+): hp is SecondLayerHandlerProcessor<CosmosHandlerKind.BatchEvent, DefaultFilter, E> {
+  return hp.baseHandlerKind === CosmosHandlerKind.BatchEvent;
+}
+
+export function isBatchTransactionHandlerProcessor<E>(
+  hp: SecondLayerHandlerProcessorArray<CosmosHandlerKind, DefaultFilter, unknown>
+): hp is SecondLayerHandlerProcessor<CosmosHandlerKind.BatchTransaction, DefaultFilter, E> {
+  return hp.baseHandlerKind === CosmosHandlerKind.BatchTransaction;
+}
+
+export function isBatchMessageHandlerProcessor<E>(
+  hp: SecondLayerHandlerProcessorArray<CosmosHandlerKind, DefaultFilter, unknown>
+): hp is SecondLayerHandlerProcessor<CosmosHandlerKind.BatchMessage, DefaultFilter, E> {
+  return hp.baseHandlerKind === CosmosHandlerKind.BatchMessage;
+}
+
 export function isCosmosTemplates(
   templatesData: any,
   specVersion: string

--- a/packages/common-cosmos/src/project/utils.ts
+++ b/packages/common-cosmos/src/project/utils.ts
@@ -54,6 +54,12 @@ export function isEventHandlerProcessor<E>(
   return hp.baseHandlerKind === CosmosHandlerKind.Event;
 }
 
+export function isPostIndexHandlerProcessor<E>(
+  hp: SecondLayerHandlerProcessorArray<CosmosHandlerKind, DefaultFilter, unknown>
+): hp is SecondLayerHandlerProcessor<CosmosHandlerKind.PostIndex, DefaultFilter, E> {
+  return hp.baseHandlerKind === CosmosHandlerKind.PostIndex;
+}
+
 export function isCosmosTemplates(
   templatesData: any,
   specVersion: string

--- a/packages/node/src/indexer/dictionary/v1/dictionaryV1.ts
+++ b/packages/node/src/indexer/dictionary/v1/dictionaryV1.ts
@@ -132,6 +132,7 @@ function buildDictionaryQueryEntries(
       if (!filterList.length) return [];
       switch (baseHandlerKind) {
         case CosmosHandlerKind.Block:
+        case CosmosHandlerKind.PostIndex:
           for (const filter of filterList as CosmosBlockFilter[]) {
             if (filter.modulo === undefined) {
               return [];

--- a/packages/node/src/indexer/dictionary/v1/dictionaryV1.ts
+++ b/packages/node/src/indexer/dictionary/v1/dictionaryV1.ts
@@ -94,6 +94,8 @@ function getBaseHandlerFilters<T extends CosmosHandlerFilter>(
   }
 }
 
+// Adding batches move complexity over 22 and the eslint rule is 20
+// eslint-disable-next-line complexity
 function buildDictionaryQueryEntries(
   dataSources: CosmosDatasource[],
   getDsProcessor: GetDsProcessor,
@@ -139,7 +141,8 @@ function buildDictionaryQueryEntries(
             }
           }
           break;
-        case CosmosHandlerKind.Message: {
+        case CosmosHandlerKind.Message:
+        case CosmosHandlerKind.BatchMessage:
           for (const filter of filterList as CosmosMessageFilter[]) {
             if (filter.type !== undefined) {
               queryEntries.push(messageFilterToQueryEntry(filter));
@@ -148,8 +151,8 @@ function buildDictionaryQueryEntries(
             }
           }
           break;
-        }
-        case CosmosHandlerKind.Event: {
+        case CosmosHandlerKind.Event:
+        case CosmosHandlerKind.BatchEvent:
           for (const filter of filterList as CosmosEventFilter[]) {
             if (filter.type !== undefined) {
               queryEntries.push(eventFilterToQueryEntry(filter));
@@ -158,7 +161,6 @@ function buildDictionaryQueryEntries(
             }
           }
           break;
-        }
         default:
       }
     }

--- a/packages/node/src/indexer/dynamic-ds.service.ts
+++ b/packages/node/src/indexer/dynamic-ds.service.ts
@@ -13,8 +13,8 @@ import {
   DynamicDsService as BaseDynamicDsService,
 } from '@subql/node-core';
 import { CosmosDatasource, CosmosHandlerKind } from '@subql/types-cosmos';
-import { plainToClass, ClassConstructor } from 'class-transformer';
-import { validateSync, IsOptional, IsObject } from 'class-validator';
+import { ClassConstructor, plainToClass } from 'class-transformer';
+import { IsObject, IsOptional, validateSync } from 'class-validator';
 import { SubqueryProject } from '../configure/SubqueryProject';
 import { DsProcessorService } from './ds-processor.service';
 
@@ -83,6 +83,7 @@ export class DynamicDsService extends BaseDynamicDsService<
         dsObj.mapping.handlers = dsObj.mapping.handlers.map((handler) => {
           switch (handler.kind) {
             case CosmosHandlerKind.Event:
+            case CosmosHandlerKind.BatchEvent:
               assert(
                 handler.filter,
                 'Dynamic datasources must have some predfined filter',
@@ -106,6 +107,7 @@ export class DynamicDsService extends BaseDynamicDsService<
               }
               return handler;
             case CosmosHandlerKind.Message:
+            case CosmosHandlerKind.BatchMessage:
               assert(
                 handler.filter,
                 'Dynamic datasources must have some predfined filter',
@@ -123,6 +125,7 @@ export class DynamicDsService extends BaseDynamicDsService<
               }
               return handler;
             case CosmosHandlerKind.Transaction:
+            case CosmosHandlerKind.BatchTransaction:
             case CosmosHandlerKind.Block:
             case CosmosHandlerKind.PostIndex:
             default:

--- a/packages/node/src/indexer/dynamic-ds.service.ts
+++ b/packages/node/src/indexer/dynamic-ds.service.ts
@@ -124,6 +124,7 @@ export class DynamicDsService extends BaseDynamicDsService<
               return handler;
             case CosmosHandlerKind.Transaction:
             case CosmosHandlerKind.Block:
+            case CosmosHandlerKind.PostIndex:
             default:
               return handler;
           }

--- a/packages/node/src/utils/cosmos.spec.ts
+++ b/packages/node/src/utils/cosmos.spec.ts
@@ -121,11 +121,11 @@ describe('CosmosUtils', () => {
       expect(event.idx).toEqual(17);
 
       expect(event.msg).toBeDefined();
-      expect(event.msg.msg.typeUrl).toEqual(
+      expect(event.msg?.msg.typeUrl).toEqual(
         '/cosmwasm.wasm.v1.MsgExecuteContract',
       );
 
-      expect(event.msg.tx.hash).toEqual(event.tx.hash);
+      expect(event.msg?.tx.hash).toEqual(event.tx?.hash);
 
       expect(event.event).toBeDefined();
       expect(event.event.type).toEqual(
@@ -393,11 +393,11 @@ describe('Cosmos 0.50 support', () => {
     expect(event.idx).toEqual(0);
 
     expect(event.msg).toBeDefined();
-    expect(event.msg.msg.typeUrl).toEqual(
+    expect(event.msg?.msg.typeUrl).toEqual(
       '/ibc.core.client.v1.MsgUpdateClient',
     );
 
-    expect(event.msg.tx.hash).toEqual(event.tx.hash);
+    expect(event.msg?.tx.hash).toEqual(event.tx?.hash);
 
     expect(event.event).toBeDefined();
     expect(event.event.type).toEqual('message');

--- a/packages/node/src/utils/cosmos.ts
+++ b/packages/node/src/utils/cosmos.ts
@@ -9,31 +9,31 @@ import { DecodeObject, decodeTxRaw, Registry } from '@cosmjs/proto-signing';
 import { fromTendermintEvent } from '@cosmjs/stargate';
 import { Log, parseRawLog } from '@cosmjs/stargate/build/logs';
 import {
-  toRfc3339WithNanoseconds,
+  comet38,
   tendermint34,
   tendermint37,
-  comet38,
+  toRfc3339WithNanoseconds,
 } from '@cosmjs/tendermint-rpc';
 
 import {
-  IBlock,
+  filterBlockTimestamp,
   getLogger,
   Header,
-  filterBlockTimestamp,
+  IBlock,
 } from '@subql/node-core';
 import {
+  CosmosBlock,
+  CosmosBlockFilter,
+  CosmosEvent,
+  CosmosEventFilter,
+  CosmosEventKind,
+  CosmosMessage,
+  CosmosMessageFilter,
+  CosmosTransaction,
+  CosmosTxFilter,
+  Header as CosmosHeader,
   TxData,
   TxEvent,
-  Header as CosmosHeader,
-  CosmosEventFilter,
-  CosmosMessageFilter,
-  CosmosBlock,
-  CosmosEvent,
-  CosmosTransaction,
-  CosmosMessage,
-  CosmosBlockFilter,
-  CosmosTxFilter,
-  CosmosEventKind,
 } from '@subql/types-cosmos';
 import { isObjectLike } from 'lodash';
 import { isLong } from 'long';
@@ -108,6 +108,13 @@ export function filterTx(
   return true;
 }
 
+export function filterBatchTxs(
+  data: CosmosTransaction[],
+  filter?: CosmosTxFilter,
+): boolean {
+  return data.every((tx) => filterTx(tx, filter));
+}
+
 export function filterMessageData(
   data: CosmosMessage,
   filter?: CosmosMessageFilter,
@@ -167,6 +174,13 @@ export function filterMessageData(
   return true;
 }
 
+export function filterBatchMessages(
+  data: CosmosMessage[],
+  filter?: CosmosMessageFilter,
+): boolean {
+  return data.every((msg) => filterMessageData(msg, filter));
+}
+
 export function filterMessages(
   messages: CosmosMessage[],
   filterOrFilters?: CosmosMessageFilter | CosmosMessageFilter[] | undefined,
@@ -219,6 +233,13 @@ export function filterEvent(
   }
 
   return true;
+}
+
+export function filterBatchEvents(
+  data: CosmosEvent[],
+  filter?: CosmosEventFilter,
+): boolean {
+  return data.every((event) => filterEvent(event, filter));
 }
 
 export function filterEvents(

--- a/packages/node/src/utils/cosmos.ts
+++ b/packages/node/src/utils/cosmos.ts
@@ -33,6 +33,7 @@ import {
   CosmosMessage,
   CosmosBlockFilter,
   CosmosTxFilter,
+  CosmosEventKind,
 } from '@subql/types-cosmos';
 import { isObjectLike } from 'lodash';
 import { isLong } from 'long';
@@ -342,6 +343,7 @@ export function wrapBlockBeginAndEndEvents(
   block: CosmosBlock,
   events: TxEvent[],
   idxOffset: number,
+  kind: CosmosEventKind,
 ): CosmosEvent[] {
   return events.map(
     (event) =>
@@ -352,6 +354,7 @@ export function wrapBlockBeginAndEndEvents(
         msg: null,
         tx: null,
         log: null,
+        kind: kind,
       } as unknown as CosmosEvent),
   );
 }
@@ -371,7 +374,12 @@ export function wrapEvent(
 ): CosmosEvent[] {
   const events: CosmosEvent[] = [];
   for (const tx of txs) {
-    const appendEvent = (msg: CosmosMessage, event: TxEvent, log: Log) => {
+    const appendEvent = (
+      msg: CosmosMessage | undefined,
+      event: TxEvent,
+      log: Log,
+      kind: CosmosEventKind,
+    ) => {
       events.push({
         idx: idxOffset++,
         block,
@@ -379,6 +387,7 @@ export function wrapEvent(
         msg,
         event,
         log,
+        kind,
       });
     };
 
@@ -410,7 +419,7 @@ export function wrapEvent(
           continue;
         }
         for (let i = 0; i < log.events.length; i++) {
-          appendEvent(msg, log.events[i], log);
+          appendEvent(msg, log.events[i], log, CosmosEventKind.Message);
         }
       }
     } else if (tx.tx?.events) {
@@ -424,6 +433,12 @@ export function wrapEvent(
 
           // Event doesn't have a message
           if (eventMsgIndex === undefined) {
+            appendEvent(
+              undefined,
+              txEvent,
+              { events: [], log: '', msg_index: -1 },
+              CosmosEventKind.Transaction,
+            );
             continue;
           }
 
@@ -435,7 +450,12 @@ export function wrapEvent(
         }
 
         // TODO does a log still exist in Comet38?
-        appendEvent(msg, txEvent, { events: [], log: '', msg_index: -1 });
+        appendEvent(
+          msg,
+          txEvent,
+          { events: [], log: '', msg_index: -1 },
+          CosmosEventKind.Message,
+        );
       }
     } else {
       // For some tests that have invalid data
@@ -562,6 +582,7 @@ export class LazyBlockContent implements BlockContent {
         this.block,
         [...results.beginBlockEvents],
         this._eventIdx,
+        CosmosEventKind.BeginBlock,
       );
       this._eventIdx += this._wrappedBeginBlockEvents.length;
     }
@@ -582,6 +603,7 @@ export class LazyBlockContent implements BlockContent {
         this.block,
         [...results.endBlockEvents],
         this._eventIdx,
+        CosmosEventKind.EndBlock,
       );
       this._eventIdx += this._wrappedEndBlockEvents.length;
     }
@@ -600,6 +622,7 @@ export class LazyBlockContent implements BlockContent {
         this.block,
         [...results.finalizeBlockEvents],
         this._eventIdx,
+        CosmosEventKind.FinalizeBlock,
       );
       this._eventIdx += this._wrappedFinalizedBlockEvents.length;
     }

--- a/packages/node/src/utils/cosmos.ts
+++ b/packages/node/src/utils/cosmos.ts
@@ -123,7 +123,10 @@ export function filterMessageData(
   if (!filterTx(data.tx, filter)) {
     return false;
   }
-  if (filter.type !== data.msg.typeUrl) {
+  if (filter.type !== '*' && filter.type !== data.msg.typeUrl) {
+    logger.debug(
+      `filtered out message type ${filter.type} != ${data.msg.typeUrl}`,
+    );
     return false;
   }
   if (filter.values) {

--- a/packages/types/src/interfaces.ts
+++ b/packages/types/src/interfaces.ts
@@ -46,13 +46,23 @@ export interface CosmosMessage<T = any> {
   };
 }
 
+export enum CosmosEventKind {
+  BeginBlock = 'begin_block',
+  EndBlock = 'end_block',
+  FinalizeBlock = 'finalize_block',
+  Message = 'message',
+  Transaction = 'transaction',
+}
+
 export interface CosmosEvent {
   idx: number;
   block: CosmosBlock;
-  tx: CosmosTransaction;
-  msg: CosmosMessage;
+  // tx and msg are optional because this is a shared interface that is use with begin, end and finalize block events.
+  tx?: CosmosTransaction;
+  msg?: CosmosMessage;
   log: Log;
   event: TxEvent;
+  kind: CosmosEventKind;
 }
 
 export type DynamicDatasourceCreator = (name: string, args: Record<string, unknown>) => Promise<void>;

--- a/packages/types/src/project.ts
+++ b/packages/types/src/project.ts
@@ -69,6 +69,10 @@ export enum CosmosHandlerKind {
    * Handler for Cosmos events.
    */
   Event = 'cosmos/EventHandler',
+  /**
+   * Post-processing functions
+   */
+  PostIndex = 'cosmos/PostIndexHandler',
 }
 
 export type CosmosRuntimeHandlerInputMap = {
@@ -76,6 +80,7 @@ export type CosmosRuntimeHandlerInputMap = {
   [CosmosHandlerKind.Transaction]: CosmosTransaction;
   [CosmosHandlerKind.Message]: CosmosMessage;
   [CosmosHandlerKind.Event]: CosmosEvent;
+  [CosmosHandlerKind.PostIndex]: CosmosBlock;
 };
 
 type CosmosRuntimeFilterMap = {
@@ -83,6 +88,7 @@ type CosmosRuntimeFilterMap = {
   [CosmosHandlerKind.Transaction]: CosmosTxFilter;
   [CosmosHandlerKind.Message]: CosmosMessageFilter;
   [CosmosHandlerKind.Event]: CosmosEventFilter;
+  [CosmosHandlerKind.PostIndex]: CosmosBlockFilter;
 };
 
 /**
@@ -199,6 +205,12 @@ export type CosmosMessageHandler = CosmosCustomHandler<CosmosHandlerKind.Message
 export type CosmosEventHandler = CosmosCustomHandler<CosmosHandlerKind.Event, CosmosEventFilter>;
 
 /**
+ * Represents a handler for Cosmos post-index blocks.
+ * @type {CosmosCustomHandler<CosmosHandlerKind.PostIndex, CosmosBlockFilter>}
+ */
+export type CosmosPostIndexBlockHandler = CosmosCustomHandler<CosmosHandlerKind.PostIndex, CosmosBlockFilter>;
+
+/**
  * Represents a generic custom handler for Cosmos.
  * @interface
  * @template K - The kind of the handler (default: string).
@@ -208,7 +220,7 @@ export interface CosmosCustomHandler<K extends string = string, F = Record<strin
   /**
    * The kind of handler. For `cosmos/Runtime` datasources this is either `Block`, `Transaction`, `Message` or `Event` kinds.
    * The value of this will determine the filter options as well as the data provided to your handler function
-   * @type {CosmosHandlerKind.Block | CosmosHandlerKind.Transaction | CosmosHandlerKind.Message | CosmosHandlerKind.Event | string }
+   * @type {CosmosHandlerKind.Block | CosmosHandlerKind.Transaction | CosmosHandlerKind.Message | CosmosHandlerKind.Event | CosmosHandlerKind.PostIndex | string }
    * @example
    * kind: CosmosHandlerKind.Block // Defined with an enum, this is used for runtime datasources
    * @example
@@ -231,7 +243,8 @@ export type CosmosRuntimeHandler =
   | CosmosBlockHandler
   | CosmosTransactionHandler
   | CosmosMessageHandler
-  | CosmosEventHandler;
+  | CosmosEventHandler
+  | CosmosPostIndexBlockHandler;
 
 export type CosmosHandler = CosmosRuntimeHandler | CosmosCustomHandler;
 
@@ -398,7 +411,8 @@ export type SecondLayerHandlerProcessorArray<
   | SecondLayerHandlerProcessor<CosmosHandlerKind.Block, F, T, DS>
   | SecondLayerHandlerProcessor<CosmosHandlerKind.Transaction, F, T, DS>
   | SecondLayerHandlerProcessor<CosmosHandlerKind.Message, F, T, DS>
-  | SecondLayerHandlerProcessor<CosmosHandlerKind.Event, F, T, DS>;
+  | SecondLayerHandlerProcessor<CosmosHandlerKind.Event, F, T, DS>
+  | SecondLayerHandlerProcessor<CosmosHandlerKind.PostIndex, F, T, DS>;
 
 export type CosmosDatasourceProcessor<
   K extends string,

--- a/packages/types/src/project.ts
+++ b/packages/types/src/project.ts
@@ -70,9 +70,22 @@ export enum CosmosHandlerKind {
    */
   Event = 'cosmos/EventHandler',
   /**
-   * Post-processing functions
+   * Post-processing functions. This will always be called after all handlers have been called.
    */
   PostIndex = 'cosmos/PostIndexHandler',
+  // Batch handlers
+  /**
+   * Handler for Multiple Cosmos transactions at once.
+   */
+  BatchTransaction = 'cosmos/BatchTransactionHandler',
+  /**
+   * Handler for Multiple Cosmos messages.
+   */
+  BatchMessage = 'cosmos/BatchMessageHandler',
+  /**
+   * Handler for Multiple Cosmos events.
+   */
+  BatchEvent = 'cosmos/BatchEventHandler',
 }
 
 export type CosmosRuntimeHandlerInputMap = {
@@ -81,6 +94,10 @@ export type CosmosRuntimeHandlerInputMap = {
   [CosmosHandlerKind.Message]: CosmosMessage;
   [CosmosHandlerKind.Event]: CosmosEvent;
   [CosmosHandlerKind.PostIndex]: CosmosBlock;
+  // Batch handlers
+  [CosmosHandlerKind.BatchTransaction]: CosmosTransaction[];
+  [CosmosHandlerKind.BatchMessage]: CosmosMessage[];
+  [CosmosHandlerKind.BatchEvent]: CosmosEvent[];
 };
 
 type CosmosRuntimeFilterMap = {
@@ -89,6 +106,10 @@ type CosmosRuntimeFilterMap = {
   [CosmosHandlerKind.Message]: CosmosMessageFilter;
   [CosmosHandlerKind.Event]: CosmosEventFilter;
   [CosmosHandlerKind.PostIndex]: CosmosBlockFilter;
+  // Batch handlers
+  [CosmosHandlerKind.BatchTransaction]: CosmosTxFilter;
+  [CosmosHandlerKind.BatchMessage]: CosmosMessageFilter;
+  [CosmosHandlerKind.BatchEvent]: CosmosEventFilter;
 };
 
 /**
@@ -203,12 +224,27 @@ export type CosmosMessageHandler = CosmosCustomHandler<CosmosHandlerKind.Message
  * @type {CosmosCustomHandler<CosmosHandlerKind.Event, CosmosEventFilter>}
  */
 export type CosmosEventHandler = CosmosCustomHandler<CosmosHandlerKind.Event, CosmosEventFilter>;
-
 /**
  * Represents a handler for Cosmos post-index blocks.
  * @type {CosmosCustomHandler<CosmosHandlerKind.PostIndex, CosmosBlockFilter>}
  */
 export type CosmosPostIndexBlockHandler = CosmosCustomHandler<CosmosHandlerKind.PostIndex, CosmosBlockFilter>;
+// Batch handlers
+/**
+ * Represents a handler for Multiple Cosmos transactions.
+ * @type {CosmosCustomHandler<CosmosHandlerKind.BatchTransaction, CosmosTxFilter>}
+ */
+export type BatchCosmosTransactionHandler = CosmosCustomHandler<CosmosHandlerKind.BatchTransaction, CosmosTxFilter>;
+/**
+ * Represents a handler for Multiple Cosmos messages.
+ * @type {CosmosCustomHandler<CosmosHandlerKind.BatchMessage, CosmosMessageFilter>}
+ */
+export type BatchCosmosMessageHandler = CosmosCustomHandler<CosmosHandlerKind.BatchMessage, CosmosMessageFilter>;
+/**
+ * Represents a handler for Multiple Cosmos events.
+ * @type {CosmosCustomHandler<CosmosHandlerKind.BatchEvent, CosmosEventFilter>}
+ */
+export type BatchCosmosEventHandler = CosmosCustomHandler<CosmosHandlerKind.BatchEvent, CosmosEventFilter>;
 
 /**
  * Represents a generic custom handler for Cosmos.
@@ -220,7 +256,7 @@ export interface CosmosCustomHandler<K extends string = string, F = Record<strin
   /**
    * The kind of handler. For `cosmos/Runtime` datasources this is either `Block`, `Transaction`, `Message` or `Event` kinds.
    * The value of this will determine the filter options as well as the data provided to your handler function
-   * @type {CosmosHandlerKind.Block | CosmosHandlerKind.Transaction | CosmosHandlerKind.Message | CosmosHandlerKind.Event | CosmosHandlerKind.PostIndex | string }
+   * @type {CosmosHandlerKind.Block | CosmosHandlerKind.Transaction | CosmosHandlerKind.Message | CosmosHandlerKind.Event | CosmosHandlerKind.PostIndex | CosmosHandlerKind.BatchTransaction | CosmosHandlerKind.BatchMessage | CosmosHandlerKind.BatchEvent | string }
    * @example
    * kind: CosmosHandlerKind.Block // Defined with an enum, this is used for runtime datasources
    * @example
@@ -237,14 +273,17 @@ export interface CosmosCustomHandler<K extends string = string, F = Record<strin
 
 /**
  * Represents a runtime handler for Cosmos, which can be a block handler, transaction handler, message handler, or event handler.
- * @type {CosmosBlockHandler | CosmosTransactionHandler | CosmosMessageHandler | CosmosEventHandler}
+ * @type {CosmosBlockHandler | CosmosTransactionHandler | CosmosMessageHandler | CosmosEventHandler | BatchCosmosTransactionHandler | BatchCosmosMessageHandler | BatchCosmosEventHandler}
  */
 export type CosmosRuntimeHandler =
   | CosmosBlockHandler
   | CosmosTransactionHandler
   | CosmosMessageHandler
   | CosmosEventHandler
-  | CosmosPostIndexBlockHandler;
+  | CosmosPostIndexBlockHandler
+  | BatchCosmosTransactionHandler
+  | BatchCosmosMessageHandler
+  | BatchCosmosEventHandler;
 
 export type CosmosHandler = CosmosRuntimeHandler | CosmosCustomHandler;
 
@@ -412,7 +451,10 @@ export type SecondLayerHandlerProcessorArray<
   | SecondLayerHandlerProcessor<CosmosHandlerKind.Transaction, F, T, DS>
   | SecondLayerHandlerProcessor<CosmosHandlerKind.Message, F, T, DS>
   | SecondLayerHandlerProcessor<CosmosHandlerKind.Event, F, T, DS>
-  | SecondLayerHandlerProcessor<CosmosHandlerKind.PostIndex, F, T, DS>;
+  | SecondLayerHandlerProcessor<CosmosHandlerKind.PostIndex, F, T, DS>
+  | SecondLayerHandlerProcessor<CosmosHandlerKind.BatchTransaction, F, T, DS>
+  | SecondLayerHandlerProcessor<CosmosHandlerKind.BatchMessage, F, T, DS>
+  | SecondLayerHandlerProcessor<CosmosHandlerKind.BatchEvent, F, T, DS>;
 
 export type CosmosDatasourceProcessor<
   K extends string,


### PR DESCRIPTION
# Description

This PR introduces two main updates:

1. **PostIndex Handler Support**: 
   - Added support for processing *PostIndex* handlers, enabling post-processing after the indexing of block, transaction, and other related data.
   - A new `CosmosHandlerKind.PostIndex` handler was introduced alongside its respective validations and runtime handling in both `@subql/types-cosmos` and relevant runtime logic. 
   - Filter conditions, validation classes (like `PostIndexHandler`), and utility functions (e.g., `isPostIndexHandlerProcessor`) have been added to properly process `PostIndex` logic.

2. **Enhanced `CosmosEvent` with Event Sources**:
   - Extended the `CosmosEvent` interface by introducing an additional `kind` property to explicitly define the source of each event, such as `BeginBlock`, `EndBlock`, `FinalizeBlock`, `Transaction`, or `Message`. 
   - Updated event generation logic to include `kind` during the wrapping of events. This provides better contextualization of events tied to specific parts of the block lifecycle or transaction processing.

### Key Changes:
- **`@subql/types-cosmos`**:
  - Added a new `CosmosHandlerKind.PostIndex` type to define PostIndex handlers.
  - Extended `CosmosEvent` to include the `CosmosEventKind` enum and `kind` property for distinguishing event sources.
  - PostIndex handlers were added to the type structures where applicable.

- **Common Cosmos Module**:
  - Added `PostIndexHandler` class within `models.ts` to validate and map PostIndex handlers from the configuration.
  - Introduced the filter handling logic for PostIndex in `utils.ts`.

- **Indexer Logic in Node**:
  - Enhanced performance for message and event indexing by building maps (`msgsTxMap`, `evntsTxMap`) to efficiently group and access events or messages without redundant filtering.
  - Implemented the `postIndexHook` method inside the `IndexerManager`, triggering "PostIndex" handlers on the consolidated block.

- **Event Wrapping & Context Handling**:
  - Updated the `wrapBlockEvents`, `wrapTxEvents`, and others to assign the corresponding `CosmosEventKind` to each event properly.

This change also addresses inefficiencies in filtering messages and events for each transaction by introducing maps to avoid redundant iterations over already-processed objects.  

### Fix Details:
This PR indirectly resolves issues related to filtering `non-msg-index` attributes, particularly events triggered outside of regular messages or transactions (e.g., `BeginBlock`, `EndBlock`, `FinalizeBlock`, and `Transaction`-only events). For example:
- Events without `msg_index` (such as `fee`, `tips`, or other external events) are now properly processed due to the inclusion of `evntsTxMap.nonMsg`.

Fixes # (specific issue reference, if applicable).

---

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update.

---

## Checklist

- [x] I have tested locally.
- [x] I have performed a self-review of my changes.
- [ ] Updated any relevant documentation.
- [ ] Linked to any relevant issues.
- [ ] I have added tests relevant to my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [ ] My code is up to date with the base branch.
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan).