### PR TITLE
Improve block iteration, fix missing non-message events, add event type

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update block type to allow access to decoded transactions, messages and events (#305)
 
 ## [4.3.0] - 2024-12-17
 ### Changed

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -115,18 +115,39 @@ export class IndexerManager extends BaseIndexerManager<
       await this.indexEvent(evt, dataSources, getVM);
     }
 
+    // Group messages so we only iterate once.
+    const groupedMessages = blockContent.messages.reduce((acc, msg) => {
+      acc[msg.tx.hash] ??= [];
+      acc[msg.tx.hash].push(msg);
+      return acc;
+    }, {} as Record<string, CosmosMessage[]>);
+
+    // Group events so we only iterate once.
+    const groupedEvents = blockContent.events.reduce((acc, evt) => {
+      acc[evt.tx.hash] ??= {};
+      // -1 for events that arent associated with a message
+      const idxKey = evt.msg?.idx ?? -1;
+      acc[evt.tx.hash][idxKey] ??= [];
+      acc[evt.tx.hash][idxKey].push(evt);
+      return acc;
+    }, {} as Record<string /* TX hash*/, Record<number /* MSG index or -1 for tx event */, CosmosEvent[]>>);
+
     for (const tx of blockContent.transactions) {
       await this.indexTransaction(tx, dataSources, getVM);
-      const msgs = blockContent.messages.filter(
-        (msg) => msg.tx.hash === tx.hash,
-      );
-      for (const msg of msgs) {
-        await this.indexMessage(msg, dataSources, getVM);
-        const events = blockContent.events.filter(
-          (event) => event.tx.hash === tx.hash && event.msg?.idx === msg.idx,
-        );
 
-        for (const evt of events) {
+      const txEvents = groupedEvents[tx.hash];
+
+      for (const msg of groupedMessages[tx.hash]) {
+        await this.indexMessage(msg, dataSources, getVM);
+        if (txEvents) {
+          for (const evt of txEvents[msg.idx]) {
+            await this.indexEvent(evt, dataSources, getVM);
+          }
+        }
+      }
+
+      if (txEvents) {
+        for (const evt of groupedEvents[tx.hash][-1]) {
           await this.indexEvent(evt, dataSources, getVM);
         }
       }

--- a/packages/node/src/indexer/indexer.manager.ts
+++ b/packages/node/src/indexer/indexer.manager.ts
@@ -139,15 +139,15 @@ export class IndexerManager extends BaseIndexerManager<
 
       for (const msg of groupedMessages[tx.hash]) {
         await this.indexMessage(msg, dataSources, getVM);
-        if (txEvents) {
+        if (txEvents?.[msg.idx]) {
           for (const evt of txEvents[msg.idx]) {
             await this.indexEvent(evt, dataSources, getVM);
           }
         }
       }
 
-      if (txEvents) {
-        for (const evt of groupedEvents[tx.hash][-1]) {
+      if (txEvents?.[-1]) {
+        for (const evt of txEvents[-1]) {
           await this.indexEvent(evt, dataSources, getVM);
         }
       }

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update block type to allow access to decoded transactions, messages and events (#305)
 
 ## [4.0.0] - 2024-10-23
 ### Changed

--- a/packages/types/src/interfaces.ts
+++ b/packages/types/src/interfaces.ts
@@ -22,7 +22,22 @@ export interface CosmosBlock {
   blockId: BlockId;
   block: {id: string} & Block;
   header: Header; // Full header
+  /* The raw transaction data */
   txs: TxData[];
+
+  /**
+   * Decoded transactions, this is the same data as passed to a transaction handler
+   * */
+  transactions: CosmosTransaction[];
+  /**
+   * Decoded messages, this is the same data as passed to a message handler
+   * */
+  messages: CosmosMessage[];
+  /**
+   * Decoded events, this is the same data as passed to a event handler.
+   * This is all events including, beginBlockEvents, endBlockEvents and finalizedBlockEvents
+   * */
+  events: CosmosEvent[];
 }
 
 export interface CosmosTransaction {

--- a/packages/types/src/interfaces.ts
+++ b/packages/types/src/interfaces.ts
@@ -46,13 +46,22 @@ export interface CosmosMessage<T = any> {
   };
 }
 
+export enum CosmosEventKind {
+  BeginBlock = 'begin_block',
+  EndBlock = 'end_block',
+  FinalizeBlock = 'finalize_block',
+  Message = 'message',
+  Transaction = 'transaction',
+}
+
 export interface CosmosEvent {
   idx: number;
   block: CosmosBlock;
   tx: CosmosTransaction;
-  msg: CosmosMessage;
+  msg?: CosmosMessage;
   log: Log;
   event: TxEvent;
+  kind: CosmosEventKind;
 }
 
 export type DynamicDatasourceCreator = (name: string, args: Record<string, unknown>) => Promise<void>;


### PR DESCRIPTION
# Description
This addresses some issues bought up by Pocketdex in https://github.com/subquery/subql-cosmos/pull/304

* Improve iterating messages and events, this matches changes made in the other SDKs and has a large performance increase
* Fixes non-message events (tx level events) not being able to be indexed
* Adds an event type field to events to determine what phase they have come from
* Adds decoded transactions, messages and events to the block.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
