### PR TITLE
Fix client selection for chains using comet 1.0

### DIFF
--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Update RPC client selection for CometBFT v1.0 (#330)
 
 ## [5.1.0] - 2025-05-21
 ### Changed

--- a/packages/node/src/indexer/cosmosClient.connection.ts
+++ b/packages/node/src/indexer/cosmosClient.connection.ts
@@ -42,7 +42,7 @@ async function connectComet(
   if (version.startsWith('0.37.')) {
     logger.debug(`Using Tendermint 37 Client`);
     out = tm37Client;
-  } else if (version.startsWith('0.38.')) {
+  } else if (version.startsWith('0.38.') || version.startsWith('1.0.')) {
     tm37Client.disconnect();
     logger.debug(`Using Comet 38 Client`);
     out = await Comet38Client.create(client);


### PR DESCRIPTION
# Description
Comet BFT v1 was released and has a version string that was not correctly handled resulting in the wrong client being used. This follows the same logic as unreleased cosmjs changes

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [x] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
