### PR TITLE
Fix templates being excluded from the published package

### DIFF
--- a/packages/common-cosmos/package.json
+++ b/packages/common-cosmos/package.json
@@ -54,6 +54,7 @@
     "!/dist/**/*.test.js",
     "!/dist/**/*.test.d.ts",
     "!/dist/**/*.test.js.map",
+    "/templates",
     "package.json",
     "README.md",
     "CHANGELOG.md",


### PR DESCRIPTION
# Description
When trying to reduce the bundle size, the templates for codegen was accidentally excluded, this pr now includes them

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)
