### PR TITLE
Calculate block time interval from recent block headers

### DIFF
--- a/packages/common-cosmos/CHANGELOG.md
+++ b/packages/common-cosmos/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Updated `@subql/common` (#356)
 
 ## [5.5.0] - 2025-08-26
 ### Changed

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Calculate block interval from block data rather than hard coded value (#355)
+- Updated `@subql/node-core` (#356)
 
 ## [5.3.0] - 2025-08-26
 ### Changed

--- a/packages/node/CHANGELOG.md
+++ b/packages/node/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Calculate block interval from block data rather than hard coded value (#355)
 
 ## [5.3.0] - 2025-08-26
 ### Changed

--- a/packages/node/src/indexer/api.service.test.ts
+++ b/packages/node/src/indexer/api.service.test.ts
@@ -100,6 +100,19 @@ describe('ApiService', () => {
       tmpPath = await makeTempDir();
     });
 
+    it('can get the block time interval', async () => {
+      const endpoint = 'https://dymension.api.onfinality.io/tendermint/public';
+      const chainId = 'dymension_1100-1';
+
+      await prepareApiService(endpoint, chainId, tmpPath);
+      const interval = await apiService.api.getBlockInterval();
+
+      console.log('INTERVAL', interval);
+
+      expect(interval).toBeGreaterThan(0);
+      expect(interval).toBeLessThan(20_000); // 20 seconds
+    });
+
     it('Falls back on rpc if kyve fails', async () => {
       const endpoint = 'https://rpc.mainnet.archway.io:443';
       const chainId = 'archway-1';

--- a/packages/node/src/indexer/api.service.ts
+++ b/packages/node/src/indexer/api.service.ts
@@ -209,9 +209,17 @@ export class CosmosClient extends CosmWasmClient {
   }
 
   async getBlockInterval(): Promise<number> {
-    const headers = await this._cometClient.blockchain();
+    const { blockMetas } = await this._cometClient.blockchain();
 
-    const timestamps = headers.blockMetas.map((h) => h.header.time.getTime());
+    if (!blockMetas || blockMetas.length < 2) {
+      throw new Error(
+        `Insufficient block headers to calculate interval: ${
+          blockMetas?.length ?? 0
+        } headers available`,
+      );
+    }
+
+    const timestamps = blockMetas.map((h) => h.header.time.getTime());
 
     return Math.abs(
       timestamps.slice(1).reduce((sum, v, i) => sum + (v - timestamps[i]), 0) /

--- a/packages/node/src/indexer/api.service.ts
+++ b/packages/node/src/indexer/api.service.ts
@@ -6,7 +6,12 @@ import { CosmWasmClient, IndexedTx } from '@cosmjs/cosmwasm-stargate';
 import { toHex } from '@cosmjs/encoding';
 import { GeneratedType, Registry } from '@cosmjs/proto-signing';
 import { defaultRegistryTypes, SearchTxQuery } from '@cosmjs/stargate';
-import { CometClient } from '@cosmjs/tendermint-rpc';
+import {
+  Comet38Client,
+  CometClient,
+  Tendermint34Client,
+  Tendermint37Client,
+} from '@cosmjs/tendermint-rpc';
 import { Injectable, OnApplicationShutdown } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { CosmosProjectNetConfig } from '@subql/common-cosmos';
@@ -201,6 +206,17 @@ export class CosmosClient extends CosmWasmClient {
     // Types have diverged with our fork of tendermint-rpc
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     super(_cometClient as any);
+  }
+
+  async getBlockInterval(): Promise<number> {
+    const headers = await this._cometClient.blockchain();
+
+    const timestamps = headers.blockMetas.map((h) => h.header.time.getTime());
+
+    return Math.abs(
+      timestamps.slice(1).reduce((sum, v, i) => sum + (v - timestamps[i]), 0) /
+        (timestamps.length - 1),
+    );
   }
 
   // eslint-disable-next-line @typescript-eslint/require-await

--- a/packages/node/src/indexer/worker/worker.service.ts
+++ b/packages/node/src/indexer/worker/worker.service.ts
@@ -57,8 +57,8 @@ export class WorkerService extends BaseWorkerService<
     return block;
   }
 
-  protected toBlockResponse(block: BlockContent): FetchBlockResponse {
-    return cosmosBlockToHeader(block.block.header);
+  protected toBlockResponse(block: IBlock<BlockContent>): FetchBlockResponse {
+    return block.getHeader();
   }
 
   protected async processFetchedBlock(

--- a/packages/node/src/utils/cosmos.ts
+++ b/packages/node/src/utils/cosmos.ts
@@ -670,8 +670,3 @@ export class LazyBlockContent implements BlockContent {
     return this._wrappedFinalizedBlockEvents;
   }
 }
-
-export function calcInterval(api: CosmosClient): number {
-  // TODO find a way to get this from the blockchain
-  return 6000;
-}

--- a/packages/types/CHANGELOG.md
+++ b/packages/types/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Updated `@subql/types-core` (#356)
 
 ## [4.2.0] - 2025-08-26
 ### Changed


### PR DESCRIPTION
# Description
Rather than using a hard coded interval of 6 seconds, the block interval is now calculated off the average of recent block timestamps deltas.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have tested locally
- [x] I have performed a self review of my changes
- [x] Updated any relevant documentation
- [x] Linked to any relevant issues
- [x] I have added tests relevant to my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] My code is up to date with the base branch
- [ ] I have updated relevant changelogs. [We suggest using chan](https://github.com/geut/chan/tree/main/packages/chan)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Block timing is now computed from recent chain headers for more accurate intervals, with bounded results, safe fallback, and improved error logging.

* **Behavior**
  * Block response handling updated for compatibility with a different block representation.

* **Tests**
  * Added a test verifying the computed block interval falls within expected bounds.

* **Chores**
  * Changelogs updated to reflect the interval calculation change.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->